### PR TITLE
Option to protect certain route CIDRs

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -5,3 +5,4 @@ netaddr==0.7.19
 wsgiref==0.1.2
 watchdog==0.8.3
 multiping>=1.0.4
+ipaddress>=1.0.17

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'wsgiref==0.1.2',
         'watchdog==0.8.3',
         'multiping>=1.0.4',
+        'ipaddress>=1.0.17'
     ],
     classifiers          = [
         'Programming Language :: Python',

--- a/vpcrouter/__init__.py
+++ b/vpcrouter/__init__.py
@@ -15,4 +15,4 @@ limitations under the License.
 
 """
 
-__version__ = "1.8.1"
+__version__ = "1.8.2"

--- a/vpcrouter/__init__.py
+++ b/vpcrouter/__init__.py
@@ -15,4 +15,4 @@ limitations under the License.
 
 """
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"

--- a/vpcrouter/currentstate/__init__.py
+++ b/vpcrouter/currentstate/__init__.py
@@ -47,6 +47,7 @@ class _CurrentState(object):
         self.vpc_state        = {}
         self.conf             = None
         self.main_param_names = []
+        self.ignore_routes    = []
         self._vpc_router_http = None
         self._stop_all        = False
 
@@ -97,8 +98,9 @@ class _CurrentState(object):
 
         if path == "route_info":
             return {
-                "route_spec" : self.route_spec,
-                "routes"     : self.routes,
+                "route_spec"    : self.route_spec,
+                "routes"        : self.routes,
+                "ignore_routes" : self.ignore_routes
             }
 
         if path == "plugins":

--- a/vpcrouter/main/__init__.py
+++ b/vpcrouter/main/__init__.py
@@ -70,6 +70,10 @@ def _setup_arg_parser(args_list, watcher_plugin_class, health_plugin_class):
     parser.add_argument('-v', '--vpc', dest="vpc_id",
                         required=False, default=None,
                         help="the ID of the VPC in which to operate")
+    parser.add_argument('--ignore_routes', dest="ignore_routes",
+                        required=False, default=None,
+                        help="Comma separated list of CIDRs or IPs for "
+                             "routes which vpc-router should ignore.")
     parser.add_argument('--route_recheck_interval',
                         dest="route_recheck_interval",
                         required=False, default="30", type=int,
@@ -91,7 +95,7 @@ def _setup_arg_parser(args_list, watcher_plugin_class, health_plugin_class):
                              "default: %s" % monitor.MONITOR_DEFAULT_PLUGIN)
 
     arglist = ["logfile", "region_name", "vpc_id", "route_recheck_interval",
-               "verbose", "addr", "port", "mode", "health"]
+               "verbose", "addr", "port", "mode", "health", "ignore_routes"]
 
     # Inform the CurrentState object of the main config parameter names, which
     # should be rendered in an overview.
@@ -156,6 +160,13 @@ def _parse_args(args_list, watcher_plugin_class, health_plugin_class):
         # Check if a proper address was specified (already raises a suitable
         # ArgsError if not)
         utils.ip_check(conf['addr'])
+
+    if conf['ignore_routes']:
+        # Parse the list of addresses and CIDRs
+        for a in conf['ignore_routes'].split(","):
+            a = a.strip()
+            a = utils.check_valid_ip_or_cidr(a, return_as_cidr=True)
+            CURRENT_STATE.ignore_routes.append(a)
 
     # Store a reference to the config dict in the current state
     CURRENT_STATE.conf = conf


### PR DESCRIPTION
With those, vpc-router will not clean up routes that point to these CIDRs.
Useful to protect special routes to proxies and such.

Version bump.

Fixes #49.